### PR TITLE
Update to 2018 / Pad to byte / Documentation update / 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "bitbit"
-version = "0.1.2"
+version = "0.2.0"
+edition = "2018"
 description = "Bit-at-a-time reader/writer types"
 license = "MIT"
 authors = ["Robert Norris <robn@robn.io>"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! # Reading
 //!
 //! ```rust, ignore
-//! let r = File::open("./example.txt");
+//! let r = File::open("somefile")?;
 //! let mut br = BitReader::new(r);
 //!
 //! let is_one = br.read_bit()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,32 +2,49 @@
 //!
 //! # Reading
 //!
-//! ```rust,ignore
-//! let r = try!(File::open("somefile"));
+//! ```rust, ignore
+//! let r = File::open("./example.txt");
 //! let mut br = BitReader::new(r);
 //!
-//! let is_one = try!(br.read_bit());
+//! let is_one = br.read_bit()?;
 //!
-//! let byte = try!(br.read_byte());
+//! let byte = br.read_byte()?;
 //!
-//! let num = try!(br.read_bits(5));
+//! let num = br.read_bits(5)?;
+//! ```
+//! Using a buffered reader will improve performance:
+//!
+//! ```rust,ignore
+//! let r = File::open("somefile")?;
+//! let buff_reader = BufReader::new(r);
+//! let mut br: BitReader<_, MSB> = BitReader::new(buff_reader);
 //! ```
 //!
 //! # Writing
 //!
-//! ```rust,ignore
-//! let w = try!(File::create("somefile"));
+//! ```rust, ignore
+//! let w = File::create("somefile")?;
 //! let mut bw = BitWriter::new(w);
 //!
-//! try!(br.write_bit(true));
+//! bw.write_bit(true)?;
 //!
-//! try!(br.write_byte(0x55));
+//! bw.write_byte(0x55)?;
 //!
-//! try!(br.write_bits(0x15, 5));
+//! bw.write_bits(0x15, 5)?;
+//!
+//! bw.pad_to_byte();
+//! ```
+//! Using a buffered writer will improve performance
+//!
+//! ```rust, ignore
+//! let w = File::create("somefile")?;
+//! let mut buf_writer = BufWriter::new(w);
+//! let mut bw = BitWriter::new(&mut buf_writer);
+//! ...
+//! buf_writer.flush();
 //! ```
 
 pub mod reader;
-pub use reader::{BitReader,MSB,LSB};
-
+pub use reader::{BitReader, MSB, LSB};
 pub mod writer;
 pub use writer::BitWriter;


### PR DESCRIPTION
_rust/ide formatting introduced many spacing differences. If these are undesirable I can go back and back out those lines._

## 2018
Update code standards to current rust 1.33/2018. This mainly consisted of removing try! macro usage.

## pad_to_byte
The main purpose of the update was to add the functionality of pad_to_byte. Without this, mainting the state of bits written would have to be done at a program level. The necessary value 'shift' was already stored. Functionality should be added at the bit-writer level.

## Documentation
Updated documentation to reflect the above changes. Fixed errors in the documentation where bw was used instead of br so the code would not compile if tested. Made br/bw usage consistent.

## 0.2.0
I chose to bump to 0.2.0. The main reason being that for pad_to_byte to be clean it relies on NLL (Non-Lexical Lifetimes) which is a 2018 rust feature. This shouldnt really be a problem. I am unsure what will happen if current useres who are using 2015 update.
