### PR TITLE
get_mut / into_inner / read_to_byte / LSB::shift_into_place() change

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ description = "Bit-at-a-time reader/writer types"
 license = "MIT"
 authors = ["Robert Norris <robn@robn.io>"]
 repository  = "https://github.com/robn/bitbit-rs"
+keywords = ["bit", "bits", "bitreader", "bitwriter", "bitstream"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbit"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2018"
 description = "Bit-at-a-time reader/writer types"
 license = "MIT"

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -1,4 +1,4 @@
-use std::io::*;
+use std::io::{Error, ErrorKind, Read, Result};
 use std::marker::PhantomData;
 
 pub trait Bit {

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -147,8 +147,13 @@ impl<R: Read, B: Bit> BitReader<R, B> {
     }
 
     /// Gets a reference to the underlying stream.
-    pub fn get_ref(&mut self) -> &R {
+    pub fn get_ref(&self) -> &R {
         &self.r
+    }
+
+    /// Gets a mutable reference to the underlying stream.
+    pub fn get_mut(&mut self) -> &mut R {
+        &mut self.r
     }
 }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -160,7 +160,7 @@ impl<R: Read, B: Bit> BitReader<R, B> {
     /// If any bits in the current byte have been read this function
     /// returns the value of the remaining bits and by doing so skips to the start of the next byte boundary.
     pub fn read_to_byte(&mut self) -> Result<u32> {
-        if self.shift != 0 {
+        if self.shift != 0 && self.shift != 8 {
             return Ok(self.read_bits(8 - self.shift)?);
         }
         Ok(0)
@@ -282,7 +282,7 @@ mod test {
     }
 
     #[test]
-    pub fn read_bits_padding() {
+    pub fn read_bits_padding_msb() {
         let r = Cursor::new(vec![0b10011001, 0b10001001]);
         let mut br: BitReader<_, MSB> = BitReader::new(r);
         assert_eq!(br.read_to_byte().unwrap(), 0);
@@ -291,6 +291,19 @@ mod test {
         assert_eq!(br.read_to_byte().unwrap(), 0);
         assert_eq!(br.read_bits(4).unwrap(), 8);
         assert_eq!(br.read_bits(3).unwrap(), 4);
+        assert_eq!(br.read_to_byte().unwrap(), 1);
+    }
+
+    #[test]
+    pub fn read_bits_padding_lsb() {
+        let r = Cursor::new(vec![0b10011001, 0b10001001]);
+        let mut br: BitReader<_, LSB> = BitReader::new(r);
+        assert_eq!(br.read_to_byte().unwrap(), 0);
+        assert_eq!(br.read_bits(3).unwrap(), 1);
+        assert_eq!(br.read_to_byte().unwrap(), 19);
+        assert_eq!(br.read_to_byte().unwrap(), 0);
+        assert_eq!(br.read_bits(4).unwrap(), 9);
+        assert_eq!(br.read_bits(3).unwrap(), 0);
         assert_eq!(br.read_to_byte().unwrap(), 1);
     }
 }

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -152,6 +152,13 @@ impl<R: Read, B: Bit> BitReader<R, B> {
         Ok(out)
     }
 
+    /// Unwraps this `BitReader<R, _>`, returning the underlying source.
+    ///
+    /// Note that any leftover bits in the internal buffer is lost.
+    pub fn into_inner(self) -> R {
+        self.r
+    }
+
     /// Gets a reference to the underlying stream.
     pub fn get_ref(&self) -> &R {
         &self.r

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,4 +1,4 @@
-use std::io::*;
+use std::io::{Error, ErrorKind, Result, Write};
 
 /// A `BitWriter` gives a way to write single bits to a stream.
 pub struct BitWriter<W: Write> {

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -94,8 +94,13 @@ impl<W: Write> BitWriter<W> {
     }
 
     /// Gets a reference to the underlying stream.
-    pub fn get_ref(&mut self) -> &W {
+    pub fn get_ref(&self) -> &W {
         &self.w
+    }
+
+    /// Gets a mutable reference to the underlying stream.
+    pub fn get_mut(&mut self) -> &mut W{
+        &mut self.w
     }
 
     /// Zero pads current byte to end.


### PR DESCRIPTION
Added mutable reference getters to better match the functionality of the buffered reader/writer. This allows for more control over the inner streams e.g to allow a bitwise seeking wrapper.

# All changes

## read_to_byte

- Added function `is_aligned()` for use with reading or padding to a byte boundary.
- Added `read_to_byte()` for the opposite effect as `pad_to_byte()`. This also enable getting mutable reference.

## get_mut (open to ideas for implementation of this with Result)
- Added `get_mut()`. This returns a `result` when called when the internal buffer is not on a byte boundary.

## LSB::shift_into_place()

When `read_bits(0)` was called in LSB mode an overflow shift error would occur. This is due to shifting `u32 >> 32`. Changed to `word.checked_shr((32 - nbits) as u32).unwrap_or(0)` which has the same effect but is safe to use with shifts of 32. Rust panics because of undefined behavior when shifting past overflow.

## into_inner()

Added the `into_inner()` function to both the reader and writer. This matches similar wrapping types such as BufReader and BufWriter. This allows for easier conversion to the inner type to make certain actions easier or to revert the bitwriter/bitreader when it is done being used. 