### PR TITLE
Add BitWriter::take.

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -98,6 +98,9 @@ impl<W: Write> BitWriter<W> {
         &self.w
     }
 
+    /// Consumes the writer, returning the underlying stream.
+    pub fn take(self) -> W { self.w }
+
     /// Zero pads current byte to end.
     /// Used when finished writing bits to a stream to ensure the content of last byte is written.
     pub fn pad_to_byte(&mut self) -> Result<()> {


### PR DESCRIPTION
For my current project, it'd be nice if I could have a `BitWriter` own the output stream (a `Vec`, in my case) and then when I'm done writing consume the writer and retake ownership of the output. I suggest a method `take` like this.